### PR TITLE
Partially implemented ACTION parsing

### DIFF
--- a/src/into_static.rs
+++ b/src/into_static.rs
@@ -428,6 +428,7 @@ where
             tags: self.tags.into_static(),
             data: self.data.into_static(),
             raw: self.raw.into_static(),
+            action: self.action,
         }
     }
 }

--- a/src/messages/twitch_message.rs
+++ b/src/messages/twitch_message.rs
@@ -403,6 +403,7 @@ mod tests {
                 tags: Tags::default(),
                 data: Cow::default(),
                 raw: Cow::default(),
+                action: false,
             }),
             TwitchMessage::Whisper(Whisper {
                 raw: Cow::default(),


### PR DESCRIPTION
This parses actions in the `data` portion of a Privmsg

but the `tags` portion is still unimplemented

closes #16

opens #36